### PR TITLE
Improve desktop UI with theme and priority

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,17 @@
 </head>
 <body>
     <div class="container">
-        <h1>My Tasks</h1>
+        <div class="header">
+            <h1>My Tasks</h1>
+            <button id="theme-toggle" title="Toggle light/dark mode">🌗</button>
+        </div>
         <div class="input-wrapper">
             <input type="text" id="new-task" placeholder="What needs to be done?" />
+            <select id="priority">
+                <option value="low">🟢</option>
+                <option value="medium">🟡</option>
+                <option value="high">🔴</option>
+            </select>
             <button id="add-btn">Add</button>
         </div>
         <div class="search-wrapper">

--- a/script.js
+++ b/script.js
@@ -4,10 +4,22 @@ const taskList = document.getElementById('task-list');
 const filterButtons = document.querySelectorAll('.filters button[data-filter]');
 const clearCompletedBtn = document.getElementById('clear-completed');
 const searchInput = document.getElementById('search');
+const prioritySelect = document.getElementById('priority');
+const themeToggle = document.getElementById('theme-toggle');
 
 let tasks = JSON.parse(localStorage.getItem('tasks')) || [];
 let currentFilter = 'all';
 let searchQuery = '';
+let theme = localStorage.getItem('theme') || 'light';
+
+const priorityOrder = ['low', 'medium', 'high'];
+const priorityIcons = { low: '🟢', medium: '🟡', high: '🔴' };
+
+function setTheme(t) {
+    document.body.classList.toggle('dark', t === 'dark');
+    theme = t;
+    localStorage.setItem('theme', t);
+}
 
 function saveTasks() {
     localStorage.setItem('tasks', JSON.stringify(tasks));
@@ -31,6 +43,11 @@ function renderTasks() {
             checkbox.checked = task.completed;
             checkbox.addEventListener('change', () => toggleTask(task.id));
 
+            const icon = document.createElement('span');
+            icon.className = 'priority';
+            icon.textContent = priorityIcons[task.priority || 'low'];
+            icon.addEventListener('click', () => cyclePriority(task.id));
+
             const span = document.createElement('span');
             span.textContent = task.title;
             span.contentEditable = true;
@@ -48,6 +65,7 @@ function renderTasks() {
             delBtn.addEventListener('click', () => deleteTask(task.id));
 
             li.appendChild(checkbox);
+            li.appendChild(icon);
             li.appendChild(span);
             li.appendChild(editBtn);
             li.appendChild(delBtn);
@@ -57,7 +75,8 @@ function renderTasks() {
 
 function addTask(title) {
     const id = Date.now().toString();
-    tasks.push({ id, title, completed: false });
+    const priority = prioritySelect.value;
+    tasks.push({ id, title, completed: false, priority });
     saveTasks();
     renderTasks();
 }
@@ -80,11 +99,25 @@ function editTask(id, title) {
     renderTasks();
 }
 
+function cyclePriority(id) {
+    tasks = tasks.map(task => {
+        if (task.id === id) {
+            const idx = priorityOrder.indexOf(task.priority || 'low');
+            const next = priorityOrder[(idx + 1) % priorityOrder.length];
+            return { ...task, priority: next };
+        }
+        return task;
+    });
+    saveTasks();
+    renderTasks();
+}
+
 addBtn.addEventListener('click', () => {
     const value = newTaskInput.value.trim();
     if (value) {
         addTask(value);
         newTaskInput.value = '';
+        prioritySelect.value = 'low';
     }
 });
 
@@ -113,5 +146,11 @@ searchInput.addEventListener('input', () => {
     searchQuery = searchInput.value.trim();
     renderTasks();
 });
+
+themeToggle.addEventListener('click', () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+});
+
+setTheme(theme);
 
 renderTasks();

--- a/style.css
+++ b/style.css
@@ -1,6 +1,17 @@
+:root {
+    --bg-color: #f2f2f2;
+    --text-color: #333;
+    --panel-bg: #fff;
+    --border-color: #ccc;
+    --primary-color: #007BFF;
+    --danger-color: #dc3545;
+    --success-color: #28a745;
+}
+
 body {
     font-family: Arial, Helvetica, sans-serif;
-    background: #f2f2f2;
+    background: var(--bg-color);
+    color: var(--text-color);
     display: flex;
     justify-content: center;
     align-items: flex-start;
@@ -10,24 +21,46 @@ body {
     line-height: 1.6;
 }
 
+body.dark {
+    --bg-color: #121212;
+    --text-color: #eee;
+    --panel-bg: #1e1e1e;
+    --border-color: #444;
+    --primary-color: #3390ff;
+    --danger-color: #e4606d;
+    --success-color: #4caf50;
+}
+
 .container {
-    background: #fff;
+    background: var(--panel-bg);
     padding: 2rem 3rem;
     border-radius: 8px;
     box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-    width: 600px;
-    max-width: 90%;
+    width: 800px;
+    max-width: 95%;
 }
 
 h1 {
-    text-align: center;
+    margin: 0;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 1rem;
-    color: #333;
 }
 
 .input-wrapper {
     display: flex;
     margin-bottom: 1rem;
+}
+
+.input-wrapper select {
+    border: 1px solid var(--border-color);
+    background: var(--panel-bg);
+    color: inherit;
+    padding: 0.5rem;
 }
 
 .search-wrapper {
@@ -38,7 +71,7 @@ h1 {
     width: 100%;
     padding: 0.5rem 1rem;
     font-size: 1rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     outline: none;
 }
@@ -47,7 +80,7 @@ input[type="text"] {
     flex: 1;
     padding: 0.5rem 1rem;
     font-size: 1rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px 0 0 4px;
     outline: none;
 }
@@ -55,7 +88,7 @@ input[type="text"] {
 button {
     cursor: pointer;
     border: none;
-    background: #007BFF;
+    background: var(--primary-color);
     color: #fff;
     padding: 0.5rem 1rem;
     font-size: 1rem;
@@ -63,6 +96,13 @@ button {
 
 button:hover {
     background: #0056b3;
+}
+
+#theme-toggle {
+    background: transparent;
+    color: inherit;
+    font-size: 1.2rem;
+    margin-left: 1rem;
 }
 
 .filters {
@@ -75,16 +115,16 @@ button:hover {
     flex: 1;
     margin-right: 0.25rem;
     background: #e9e9e9;
-    color: #333;
+    color: var(--text-color);
 }
 
 .filters button.active, .filters button:hover {
-    background: #007BFF;
+    background: var(--primary-color);
     color: #fff;
 }
 
 .filters #clear-completed {
-    background: #dc3545;
+    background: var(--danger-color);
     color: #fff;
 }
 
@@ -97,12 +137,15 @@ ul {
 li {
     display: flex;
     align-items: center;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid #eee;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--panel-bg);
 }
 
 li:last-child {
-    border-bottom: none;
+    margin-bottom: 0;
 }
 
 li.completed span {
@@ -111,12 +154,17 @@ li.completed span {
 }
 
 li button {
-    background: #dc3545;
+    background: var(--danger-color);
     margin-left: auto;
     font-size: 0.8rem;
 }
 
 li button.edit {
-    background: #28a745;
+    background: var(--success-color);
     margin-right: 0.5rem;
+}
+
+.priority {
+    margin: 0 0.5rem;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add header with theme toggle and priority selector
- support priority icons and cycling between levels
- persist theme choice and priority
- redesign styles for light/dark mode and panel layout

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684033600fec83218e755a7fc9449a56